### PR TITLE
Minor updates

### DIFF
--- a/resources/views/components/page.blade.php
+++ b/resources/views/components/page.blade.php
@@ -1,6 +1,10 @@
+@props([
+    'innerNav' => null,
+])
+
 @php
     /** @var \Rawilk\FilamentInnerNav\InnerNav $innerNav */
-    $innerNav = static::getResource()::innerNav($this->record ?? null, $this);
+    $innerNav = $innerNav ?? static::getResource()::innerNav($this->record ?? null, $this);
 
     $isTopLayout = $innerNav->isLayout(\Rawilk\FilamentInnerNav\Enums\InnerNavLayout::Top);
 @endphp

--- a/resources/views/layouts/layout-side.blade.php
+++ b/resources/views/layouts/layout-side.blade.php
@@ -66,30 +66,28 @@
             'mt-4' => filled($navTitle) || filled($navDescription),
         ])>
             @foreach ($innerNav->getNavigationItems() as $item)
-                @unless ($item->isHidden())
-                    @if ($item instanceof \Rawilk\FilamentInnerNav\InnerNavGroup)
-                        <x-filament-inner-nav::group-item
-                            :group="$item"
-                            :wire-navigate="$shouldWireNavigate"
-                        >
-                            {{ $item->getLabel() }}
-                        </x-filament-inner-nav::group-item>
-                    @else
-                        <x-filament-inner-nav::item
-                            :active="$item->isActive()"
-                            :icon="$item->getIcon()"
-                            :active-icon="$item->getActiveIcon()"
-                            :href="$item->getUrl()"
-                            :badge="$item->getBadge()"
-                            :badge-color="$item->getBadgeColor()"
-                            :should-open-url-in-new-tab="$item->shouldOpenUrlInNewTab()"
-                            :wire-navigate="$shouldWireNavigate"
-                            :disabled="$item->getIsDisabled()"
-                        >
-                            {{ $item->getLabel() }}
-                        </x-filament-inner-nav::item>
-                    @endif
-                @endunless
+                @if ($item instanceof \Rawilk\FilamentInnerNav\InnerNavGroup)
+                    <x-filament-inner-nav::group-item
+                        :group="$item"
+                        :wire-navigate="$shouldWireNavigate"
+                    >
+                        {{ $item->getLabel() }}
+                    </x-filament-inner-nav::group-item>
+                @else
+                    <x-filament-inner-nav::item
+                        :active="$item->isActive()"
+                        :icon="$item->getIcon()"
+                        :active-icon="$item->getActiveIcon()"
+                        :href="$item->getUrl()"
+                        :badge="$item->getBadge()"
+                        :badge-color="$item->getBadgeColor()"
+                        :should-open-url-in-new-tab="$item->shouldOpenUrlInNewTab()"
+                        :wire-navigate="$shouldWireNavigate"
+                        :disabled="$item->getIsDisabled()"
+                    >
+                        {{ $item->getLabel() }}
+                    </x-filament-inner-nav::item>
+                @endif
             @endforeach
         </ul>
     </div>

--- a/resources/views/layouts/layout-top.blade.php
+++ b/resources/views/layouts/layout-top.blade.php
@@ -17,28 +17,26 @@
     <div>
         <nav class="flex flex-col sm:flex-row gap-2 sm:flex-wrap -mx-3">
             @foreach ($innerNav->getNavigationItems() as $item)
-                @unless ($item->isHidden())
-                    @if ($item instanceof \Rawilk\FilamentInnerNav\InnerNavGroup)
-                        <x-filament-inner-nav::top-group-item
-                            :group="$item"
-                            :wire-navigate="$shouldWireNavigate"
-                        />
-                    @else
-                        <x-filament-inner-nav::top-item
-                            :active="$item->isActive()"
-                            :icon="$item->getIcon()"
-                            :active-icon="$item->getActiveIcon()"
-                            :href="$item->getUrl()"
-                            :badge="$item->getBadge()"
-                            :badge-color="$item->getBadgeColor()"
-                            :should-open-url-in-new-tab="$item->shouldOpenUrlInNewTab()"
-                            :wire-navigate="$shouldWireNavigate"
-                            :disabled="$item->getIsDisabled()"
-                        >
-                            {{ $item->getLabel() }}
-                        </x-filament-inner-nav::top-item>
-                    @endif
-                @endunless
+                @if ($item instanceof \Rawilk\FilamentInnerNav\InnerNavGroup)
+                    <x-filament-inner-nav::top-group-item
+                        :group="$item"
+                        :wire-navigate="$shouldWireNavigate"
+                    />
+                @else
+                    <x-filament-inner-nav::top-item
+                        :active="$item->isActive()"
+                        :icon="$item->getIcon()"
+                        :active-icon="$item->getActiveIcon()"
+                        :href="$item->getUrl()"
+                        :badge="$item->getBadge()"
+                        :badge-color="$item->getBadgeColor()"
+                        :should-open-url-in-new-tab="$item->shouldOpenUrlInNewTab()"
+                        :wire-navigate="$shouldWireNavigate"
+                        :disabled="$item->getIsDisabled()"
+                    >
+                        {{ $item->getLabel() }}
+                    </x-filament-inner-nav::top-item>
+                @endif
             @endforeach
         </nav>
     </div>

--- a/src/InnerNav.php
+++ b/src/InnerNav.php
@@ -79,11 +79,13 @@ class InnerNav extends NavigationBuilder
     }
 
     /**
-     * @return \Illuminate\Support\Collection|array<int, \Rawilk\FilamentInnerNav\InnerNavItem|\Rawilk\FilamentInnerNav\InnerNavGroup>
+     * @return \Illuminate\Support\Collection<int, \Rawilk\FilamentInnerNav\InnerNavItem|\Rawilk\FilamentInnerNav\InnerNavGroup>
      */
-    public function getNavigationItems(): array|Collection
+    public function getNavigationItems(): Collection
     {
-        return $this->navigationItems;
+        return collect($this->navigationItems)
+            ->reject(fn (InnerNavItem|InnerNavGroup $item): bool => $item->isHidden())
+            ->sortBy(fn (InnerNavItem|InnerNavGroup $item): int => $item->getSort());
     }
 
     public function setLayout(InnerNavLayout|Closure $layout): self

--- a/src/InnerNav.php
+++ b/src/InnerNav.php
@@ -10,6 +10,7 @@ use Filament\Pages\Page;
 use Filament\Support\Concerns\Configurable;
 use Filament\Support\Concerns\EvaluatesClosures;
 use Illuminate\Contracts\View\View;
+use Illuminate\Support\Collection;
 use Illuminate\Support\HtmlString;
 use Rawilk\FilamentInnerNav\Enums\InnerNavLayout;
 
@@ -26,7 +27,7 @@ class InnerNav extends NavigationBuilder
 
     protected bool|Closure $isWireNavigate = false;
 
-    protected array $navigationItems;
+    protected array|Collection $navigationItems;
 
     public function __construct(protected ?Page $page = null)
     {
@@ -70,7 +71,7 @@ class InnerNav extends NavigationBuilder
         return $this->evaluate($this->description);
     }
 
-    public function setNavigationItems(array $navigationItems): self
+    public function setNavigationItems(array|Collection $navigationItems): self
     {
         $this->navigationItems = $navigationItems;
 
@@ -78,9 +79,9 @@ class InnerNav extends NavigationBuilder
     }
 
     /**
-     * @return array<int, \Rawilk\FilamentInnerNav\InnerNavItem>
+     * @return \Illuminate\Support\Collection|array<int, \Rawilk\FilamentInnerNav\InnerNavItem|\Rawilk\FilamentInnerNav\InnerNavGroup>
      */
-    public function getNavigationItems(): array
+    public function getNavigationItems(): array|Collection
     {
         return $this->navigationItems;
     }

--- a/src/InnerNavGroup.php
+++ b/src/InnerNavGroup.php
@@ -75,6 +75,13 @@ class InnerNavGroup extends NavigationGroup
         return $this;
     }
 
+    public function getItems(): array|Arrayable
+    {
+        return collect($this->items)
+            ->reject(fn (InnerNavItem|InnerNavGroup $item): bool => $item->isHidden())
+            ->sortBy(fn (InnerNavItem|InnerNavGroup $item): int => $item->getSort());
+    }
+
     /**
      * We're overriding this method because our inner nav layout will take care of not rendering group icons
      * in collapsible groups.

--- a/src/InnerNavGroup.php
+++ b/src/InnerNavGroup.php
@@ -18,7 +18,9 @@ class InnerNavGroup extends NavigationGroup
 
     protected bool|Closure $shouldExpandByDefault = false;
 
-    public function expandByDefault(bool|Closure $condition): self
+    protected int|Closure|null $sort = null;
+
+    public function expandByDefault(bool|Closure $condition): static
     {
         $this->shouldExpandByDefault = $condition;
 
@@ -71,5 +73,26 @@ class InnerNavGroup extends NavigationGroup
         $this->items = $items;
 
         return $this;
+    }
+
+    /**
+     * We're overriding this method because our inner nav layout will take care of not rendering group icons
+     * in collapsible groups.
+     */
+    public function getIcon(): ?string
+    {
+        return $this->evaluate($this->icon);
+    }
+
+    public function sort(int|Closure|null $sort): static
+    {
+        $this->sort = $sort;
+
+        return $this;
+    }
+
+    public function getSort(): int
+    {
+        return $this->evaluate($this->sort) ?? -1;
     }
 }


### PR DESCRIPTION
PR introduces some minor updates, including:

- Allow `InnerNav` instances to be passed in as a prop on the `filament-inner-nav::page` component
- Add a sort order property to `InnerNavGroup`
- Override the `getIcon` method on `InnerNavGroup` to allow for both the group and its items to have icons
- Allow navigation items in `InnerNav` to be either a collection or array
- Ensure group items are hidden and sorted correctly when `getItems()` is called on `InnerNavGroup`
- Reject and sort items/groups on the `InnerNav` object itself instead of in a blade file
